### PR TITLE
Remove duplicate save attribute.

### DIFF
--- a/SOLVER/nc_routines.F90
+++ b/SOLVER/nc_routines.F90
@@ -82,29 +82,29 @@ module nc_routines
     !> Mapping of local fluid points to global
     integer             :: npts_flu_myfirst, npts_flu_mylast
 
-    integer, save      :: ncid_out, ncid_recout, ncid_snapout, ncid_surfout, ncid_meshout
-    integer, save      :: nc_snap_dimid, nc_proc_dimid, nc_rec_dimid, nc_recproc_dimid
-    integer, save      :: nc_times_dimid, nc_comp_dimid, nc_disp_varid, nc_stf_seis_varid
-    integer, save      :: nc_time_varid, nc_iter_dimid, nc_stf_iter_varid
+    integer            :: ncid_out, ncid_recout, ncid_snapout, ncid_surfout, ncid_meshout
+    integer            :: nc_snap_dimid, nc_proc_dimid, nc_rec_dimid, nc_recproc_dimid
+    integer            :: nc_times_dimid, nc_comp_dimid, nc_disp_varid, nc_stf_seis_varid
+    integer            :: nc_time_varid, nc_iter_dimid, nc_stf_iter_varid
 
-    integer, save      :: nc_strcomp_dimid
-    integer, save      :: nc_surfelem_disp_varid, nc_surfelem_velo_varid
-    integer, save      :: nc_surfelem_strain_varid, nc_surfelem_disp_src_varid
-    integer, save      :: nc_mesh_sol_varid, nc_mesh_flu_varid, nc_stf_dump_varid
-    integer, save      :: nc_point_dimid, nc_pt_sol_dimid, nc_pt_flu_dimid
-    integer, save      :: nc_szcoord_dimid
-    integer, save      :: nc_snaptime_varid, nc_elem_dom_varid, nc_surfelem_theta_varid
+    integer            :: nc_strcomp_dimid
+    integer            :: nc_surfelem_disp_varid, nc_surfelem_velo_varid
+    integer            :: nc_surfelem_strain_varid, nc_surfelem_disp_src_varid
+    integer            :: nc_mesh_sol_varid, nc_mesh_flu_varid, nc_stf_dump_varid
+    integer            :: nc_point_dimid, nc_pt_sol_dimid, nc_pt_flu_dimid
+    integer            :: nc_szcoord_dimid
+    integer            :: nc_snaptime_varid, nc_elem_dom_varid, nc_surfelem_theta_varid
     integer,allocatable :: nc_field_varid(:)
     character(len=16), allocatable  :: varnamelist(:)
     character(len=12), allocatable  :: nc_varnamelist(:)
     integer             :: nvar = -1
 
     !! Variables for dumping of wavefields for plotting purposes
-    integer, save       :: nc_snap_disp_varid, nc_coord_dimid
-    integer, save       :: nc_snap_point_varid, nc_snap_grid_varid
-    integer, save       :: nc_snap_pwave_varid, nc_snap_swave_varid
-    integer, save       :: ncid_out_snap
-    integer, save       :: ndim_disp !< 2 for monopole, 3 for rest
+    integer             :: nc_snap_disp_varid, nc_coord_dimid
+    integer             :: nc_snap_point_varid, nc_snap_grid_varid
+    integer             :: nc_snap_pwave_varid, nc_snap_swave_varid
+    integer             :: ncid_out_snap
+    integer             :: ndim_disp !< 2 for monopole, 3 for rest
 
     !! Buffer variables to hand over to the dumping thread
     real(kind=sp), allocatable, dimension(:,:,:)  :: copy_oneddumpvar         


### PR DESCRIPTION
There is already a blanket save statement for the entire module, so these save attributes induce a warning on newer compilers.

For example, with gfortran,

```
axisem/SOLVER/nc_routines.F90:107.36:
    integer, save       :: ndim_disp !< 2 for monopole, 3 for rest
                                    1
Warning: Legacy Extension: Duplicate SAVE attribute specified at (1)
```
